### PR TITLE
Update installation instructions for brew/pixman

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ To embark on your journey with Sequel, clone our project repository from GitHub 
 
 - Node.js (LTS Version recommended)
 - npm (Node Package Manager)
+- [brew](https://brew.sh/) (MacOS Package manager)
+- [bun](https://bun.sh/docs/installation) (JS/TS Toolkit)
 
 ### Installation
 
@@ -34,6 +36,7 @@ cd sequel
 
 4. Install the project dependencies:
 ```sh
+brew install pixman
 bun install
 ```
 


### PR DESCRIPTION
When first attempting a clean install, I found the following error:
```
sequel % ~/.bun/bin/bun install
...
gyp info spawn args [
gyp info spawn args   '/Users/myuser/Documents/sequel/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/myuser/Documents/sequel/node_modules/canvas/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/myuser/Documents/sequel/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/myuser/Library/Caches/node-gyp/21.6.1/include/node/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/Users/myuser/Library/Caches/node-gyp/21.6.1',
gyp info spawn args   '-Dnode_gyp_dir=/Users/myuser/Documents/sequel/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=/Users/myuser/Library/Caches/node-gyp/21.6.1/<(target_arch)/node.lib',
gyp info spawn args   '-Dmodule_root_dir=/Users/myuser/Documents/sequel/node_modules/canvas',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.'
gyp info spawn args ]
Package pixman-1 was not found in the pkg-config search path.
Perhaps you should add the directory containing `pixman-1.pc'
to the PKG_CONFIG_PATH environment variable
No package 'pixman-1' found
gyp: Call to 'pkg-config pixman-1 --libs' returned exit status 1 while in binding.gyp. while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/Users/myuser/Documents/sequel/node_modules/node-gyp/lib/configure.js:325:16)
gyp ERR! stack     at ChildProcess.emit (node:events:519:28)
gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:294:12)
gyp ERR! System Darwin 23.4.0
gyp ERR! command "/opt/homebrew/Cellar/node/21.6.1/bin/node" "/Users/myuser/Documents/sequel/node_modules/node-gyp/bin/node-gyp.js" "configure" "--fallback-to-build" "--update-binary" "--module=/Users/myuser/Documents/sequel/node_modules/canvas/build/Release/canvas.node" "--module_name=canvas" "--module_path=/Users/myuser/Documents/sequel/node_modules/canvas/build/Release" "--napi_version=9" "--node_abi_napi=napi" "--napi_build_version=0" "--node_napi_label=node-v120"
gyp ERR! cwd /Users/myuser/Documents/sequel/node_modules/canvas
gyp ERR! node -v v21.6.1
gyp ERR! node-gyp -v v9.4.1
gyp ERR! not ok 
node-pre-gyp ERR! build error 
node-pre-gyp ERR! stack Error: Failed to execute '/opt/homebrew/Cellar/node/21.6.1/bin/node /Users/myuser/Documents/sequel/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build --update-binary --module=/Users/myuser/Documents/sequel/node_modules/canvas/build/Release/canvas.node --module_name=canvas --module_path=/Users/myuser/Documents/sequel/node_modules/canvas/build/Release --napi_version=9 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v120' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/Users/myuser/Documents/sequel/node_modules/@mapbox/node-pre-gyp/lib/util/compile.js:89:23)
node-pre-gyp ERR! stack     at ChildProcess.emit (node:events:519:28)
node-pre-gyp ERR! stack     at maybeClose (node:internal/child_process:1105:16)
node-pre-gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:305:5)
node-pre-gyp ERR! System Darwin 23.4.0
node-pre-gyp ERR! command "/opt/homebrew/Cellar/node/21.6.1/bin/node" "/Users/myuser/Documents/sequel/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build" "--update-binary"
node-pre-gyp ERR! cwd /Users/myuser/Documents/sequel/node_modules/canvas
node-pre-gyp ERR! node -v v21.6.1
node-pre-gyp ERR! node-pre-gyp -v v1.0.11
node-pre-gyp ERR! not ok 

error: install script from "canvas" exited with 1
```

, essentially that `pixman` was not installed. Running `brew install pixman` fixed the issue. Also, `bun` was not installed, so I added a link to the installation guide for that tool, as well as `brew` since it's a part of the installation instructions.